### PR TITLE
power: Use POWER_HINT_LAUNCH for launch boosts

### DIFF
--- a/power/power-8916.c
+++ b/power/power-8916.c
@@ -400,7 +400,7 @@ int power_hint_override(struct power_module *module __unused, power_hint_t hint,
         return HINT_HANDLED;
     }
 
-    if (hint == POWER_HINT_LAUNCH_BOOST) {
+    if (hint == POWER_HINT_LAUNCH) {
         int duration = 2000;
         int resources[] = {
             ALL_CPUS_PWR_CLPS_DIS,

--- a/power/power-8937.c
+++ b/power/power-8937.c
@@ -130,7 +130,7 @@ int power_hint_override(__unused struct power_module *module, power_hint_t hint,
     static struct timespec s_previous_boost_timespec;
     struct timespec cur_boost_timespec;
     long long elapsed_time;
-    int resources_launch_boost[] = {
+    int resources_launch[] = {
         SCHED_BOOST_ON_V3, 0x1,
         MIN_FREQ_BIG_CORE_0, 0x5DC,
         ALL_CPUS_PWR_CLPS_DIS_V3, 0x1,
@@ -190,10 +190,10 @@ int power_hint_override(__unused struct power_module *module, power_hint_t hint,
                         resources_interaction_fling_boost);
             }
             return HINT_HANDLED;
-        case POWER_HINT_LAUNCH_BOOST:
+        case POWER_HINT_LAUNCH:
             duration = 2000;
-            interaction(duration, ARRAY_SIZE(resources_launch_boost),
-                    resources_launch_boost);
+            interaction(duration, ARRAY_SIZE(resources_launch),
+                    resources_launch);
             return HINT_HANDLED;
         case POWER_HINT_CPU_BOOST:
             duration = *(int32_t *)data / 1000;

--- a/power/power-8952.c
+++ b/power/power-8952.c
@@ -110,7 +110,7 @@ int  power_hint_override(struct power_module *module, power_hint_t hint,
     static struct timespec s_previous_boost_timespec;
     struct timespec cur_boost_timespec;
     long long elapsed_time;
-    int resources_launch_boost[] = {
+    int resources_launch[] = {
         ALL_CPUS_PWR_CLPS_DIS,
         SCHED_BOOST_ON,
         SCHED_PREFER_IDLE_DIS,
@@ -172,10 +172,10 @@ int  power_hint_override(struct power_module *module, power_hint_t hint,
                         resources_interaction_boost);
             }
             return HINT_HANDLED;
-        case POWER_HINT_LAUNCH_BOOST:
+        case POWER_HINT_LAUNCH:
             duration = 2000;
-            interaction(duration, ARRAY_SIZE(resources_launch_boost),
-                    resources_launch_boost);
+            interaction(duration, ARRAY_SIZE(resources_launch),
+                    resources_launch);
             return HINT_HANDLED;
         case POWER_HINT_CPU_BOOST:
             duration = *(int32_t *)data / 1000;

--- a/power/power-8974.c
+++ b/power/power-8974.c
@@ -140,7 +140,7 @@ int power_hint_override(__attribute__((unused)) struct power_module *module,
         return HINT_HANDLED;
     }
 
-    if (hint == POWER_HINT_LAUNCH_BOOST) {
+    if (hint == POWER_HINT_LAUNCH) {
         int duration = 2000;
         int resources[] = { CPUS_ONLINE_MIN_3,
             CPU0_MIN_FREQ_TURBO_MAX, CPU1_MIN_FREQ_TURBO_MAX,

--- a/power/power-8992.c
+++ b/power/power-8992.c
@@ -208,19 +208,10 @@ int power_hint_override(__attribute__((unused)) struct power_module *module,
         return HINT_HANDLED;
     }
 
-    if (hint == POWER_HINT_LAUNCH_BOOST) {
-        launch_boost_info_t *info = (launch_boost_info_t *)data;
-        if (info == NULL) {
-            ALOGE("Invalid argument for launch boost");
-            return HINT_HANDLED;
-        }
-
-        ALOGV("LAUNCH_BOOST: %s (pid=%d)", info->packageName, info->pid);
-
+    if (hint == POWER_HINT_LAUNCH) {
         int duration = 2000;
         int resources[] = { SCHED_BOOST_ON, 0x20C };
 
-        start_prefetch(info->pid, info->packageName);
         interaction(duration, ARRAY_SIZE(resources), resources);
 
         return HINT_HANDLED;

--- a/power/power-8994.c
+++ b/power/power-8994.c
@@ -218,19 +218,10 @@ int power_hint_override(__attribute__((unused)) struct power_module *module,
         return HINT_HANDLED;
     }
 
-    if (hint == POWER_HINT_LAUNCH_BOOST) {
-        launch_boost_info_t *info = (launch_boost_info_t *)data;
-        if (info == NULL) {
-            ALOGE("Invalid argument for launch boost");
-            return HINT_HANDLED;
-        }
-
-        ALOGV("LAUNCH_BOOST: %s (pid=%d)", info->packageName, info->pid);
-
+    if (hint == POWER_HINT_LAUNCH) {
         int duration = 2000;
         int resources[] = { SCHED_BOOST_ON, 0x20C };
 
-        start_prefetch(info->pid, info->packageName);
         interaction(duration, ARRAY_SIZE(resources), resources);
 
         return HINT_HANDLED;

--- a/power/power-8996.c
+++ b/power/power-8996.c
@@ -202,7 +202,7 @@ int power_hint_override(__unused struct power_module *module,
     long long elapsed_time;
     int duration;
 
-    int resources_launch_boost[] = {
+    int resources_launch[] = {
         SCHED_BOOST_ON_V3, 0x1,
         MAX_FREQ_BIG_CORE_0, 0xFFF,
         MAX_FREQ_LITTLE_CORE_0, 0xFFF,
@@ -266,20 +266,11 @@ int power_hint_override(__unused struct power_module *module,
         return HINT_HANDLED;
     }
 
-    if (hint == POWER_HINT_LAUNCH_BOOST) {
-        launch_boost_info_t *info = (launch_boost_info_t *)data;
-        if (info == NULL) {
-            ALOGE("Invalid argument for launch boost");
-            return HINT_HANDLED;
-        }
-
+    if (hint == POWER_HINT_LAUNCH) {
         duration = 2000;
 
-        ALOGV("LAUNCH_BOOST: %s (pid=%d)", info->packageName, info->pid);
-
-        start_prefetch(info->pid, info->packageName);
-        interaction(duration, ARRAY_SIZE(resources_launch_boost),
-                resources_launch_boost);
+        interaction(duration, ARRAY_SIZE(resources_launch),
+                resources_launch);
         return HINT_HANDLED;
     }
 

--- a/power/power.c
+++ b/power/power.c
@@ -201,7 +201,6 @@ static void power_hint(__attribute__((unused)) struct power_module *module, powe
         case POWER_HINT_VSYNC:
         case POWER_HINT_INTERACTION:
         case POWER_HINT_CPU_BOOST:
-        case POWER_HINT_LAUNCH_BOOST:
         case POWER_HINT_SET_PROFILE:
         case POWER_HINT_LOW_POWER:
         break;


### PR DESCRIPTION
AOSP introduced POWER_HINT_LAUNCH in 7.1 to indicate the
start-up of a new activity. Use it.

Change-Id: Iff336ed31a29ffc969db8eabced857bab4b941ab
Issue-Id: LINN-6